### PR TITLE
Consumindo endpoint para invalidar um boleto

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/models/recebimento/BoletoInvalido.java
+++ b/src/main/java/br/com/pjbank/sdk/models/recebimento/BoletoInvalido.java
@@ -1,0 +1,24 @@
+package br.com.pjbank.sdk.models.recebimento;
+
+/**
+ *
+ * @author lucas
+ */
+public class BoletoInvalido {
+
+    private final int status;
+    private final String message;
+
+    public BoletoInvalido(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
+++ b/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
@@ -24,8 +24,10 @@ import br.com.pjbank.sdk.api.PJBankClient;
 import br.com.pjbank.sdk.auth.PJBankAuthenticatedService;
 import br.com.pjbank.sdk.enums.StatusPagamentoBoleto;
 import br.com.pjbank.sdk.exceptions.PJBankException;
+import br.com.pjbank.sdk.models.recebimento.BoletoInvalido;
 import br.com.pjbank.sdk.models.recebimento.BoletoRecebimento;
 import br.com.pjbank.sdk.models.recebimento.ExtratoBoleto;
+import org.apache.http.client.methods.HttpDelete;
 
 /**
  * @author Vinícius Silva <vinicius.silva@superlogica.com>
@@ -163,5 +165,28 @@ public class BoletosManager extends PJBankAuthenticatedService {
         uriBuilder.addParameter("pagina", pagina.toString());
 
         httpRequestClient.setURI(uriBuilder.build());
+    }
+
+    /**
+     * Retorna um objeto BoletoInvalido com o status e mensagem.<br>Exemplo:
+     * <pre>
+     * Status: 200
+     * Mensagem: Cobrança 12345678 invalidada com sucesso.
+     * </pre>
+     *
+     * @param pedidoNumero Integer
+     * @return BoletoInvalido:
+     * @throws IOException
+     * @throws PJBankException
+     */
+    public BoletoInvalido invalidate(Integer pedidoNumero) throws IOException, PJBankException {
+        PJBankClient client = new PJBankClient(this.endPoint.concat("/transacoes/" + pedidoNumero));
+        HttpDelete httpDelete = client.getHttpDeleteClient();
+        httpDelete.addHeader("x-chave", this.getChave());
+
+        String response = EntityUtils.toString(client.doRequest(httpDelete).getEntity());
+        JSONObject responseObject = new JSONObject(response);
+
+        return new BoletoInvalido(responseObject.getInt("status"), responseObject.getString("msg"));
     }
 }

--- a/src/test/java/br/com/pjbank/sdk/recebimento/BoletosManagerTest.java
+++ b/src/test/java/br/com/pjbank/sdk/recebimento/BoletosManagerTest.java
@@ -1,5 +1,6 @@
 package br.com.pjbank.sdk.recebimento;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -26,8 +27,10 @@ import br.com.pjbank.sdk.enums.StatusPagamentoBoleto;
 import br.com.pjbank.sdk.exceptions.PJBankException;
 import br.com.pjbank.sdk.models.common.Cliente;
 import br.com.pjbank.sdk.models.common.Endereco;
+import br.com.pjbank.sdk.models.recebimento.BoletoInvalido;
 import br.com.pjbank.sdk.models.recebimento.BoletoRecebimento;
 import br.com.pjbank.sdk.models.recebimento.ExtratoBoleto;
+import org.apache.http.HttpStatus;
 
 /**
  * @author Vinícius Silva <vinicius.silva@superlogica.com>
@@ -142,4 +145,12 @@ public class BoletosManagerTest {
 
     }
     
+    @Test
+    public void invalidate() throws IOException, PJBankException{
+        BoletosManager manager = new BoletosManager(this.credencial, this.chave);
+        final BoletoInvalido boletoInvalido = manager.invalidate(89724);
+        
+        Assert.assertThat(boletoInvalido.getStatus(), is(HttpStatus.SC_OK));
+        Assert.assertThat(boletoInvalido.getMessage(), containsString("invalidada com sucesso"));
+    }
 }


### PR DESCRIPTION
Adicionando método BoletosManager#invalidate() para invalidar um boleto.

Criando classe BoletoInvalido.java para mostrar status e mensagem de retorno ao tentar invalidar um boleto.

Teste para o método BoletosManager#invalidate().
