### PR TITLE
Adicionar campos extras (pix, dias para juros/multa e dias para cancelar boleto)

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/models/common/EnumAtualizarVencimento.java
+++ b/src/main/java/br/com/pjbank/sdk/models/common/EnumAtualizarVencimento.java
@@ -1,0 +1,21 @@
+package br.com.pjbank.sdk.models.common;
+
+/**
+ *
+ * @author lucas
+ */
+public enum EnumAtualizarVencimento {
+
+    ATUALIZAR("0"),
+    NAO_ATUALIZAR("1");
+
+    private final String value;
+
+    private EnumAtualizarVencimento(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/br/com/pjbank/sdk/models/recebimento/BoletoRecebimento.java
+++ b/src/main/java/br/com/pjbank/sdk/models/recebimento/BoletoRecebimento.java
@@ -2,6 +2,7 @@ package br.com.pjbank.sdk.models.recebimento;
 
 import br.com.pjbank.sdk.models.common.Boleto;
 import br.com.pjbank.sdk.models.common.Cliente;
+import br.com.pjbank.sdk.models.common.EnumAtualizarVencimento;
 import br.com.pjbank.sdk.models.common.EnumPix;
 
 import java.util.Date;
@@ -12,6 +13,7 @@ import java.util.Date;
  * @since 1.0
  */
 public class BoletoRecebimento extends Boleto {
+
     /**
      * Dados para requisição
      */
@@ -29,10 +31,10 @@ public class BoletoRecebimento extends Boleto {
     private String texto;
     private String grupo;
     private String pedidoNumero;
-    private int diasIndisponibilizar = 58;
-    private int diasJuros = 1;
-    private int diasMulta = 1;
-    private int nuncaAtualizarBoleto = 0;
+    private String diasIndisponibilizar;
+    private String diasJuros;
+    private String diasMulta;
+    private EnumAtualizarVencimento nuncaAtualizarBoleto;
     private EnumPix pix = EnumPix.PIX_E_BOLETO;
 
     /**
@@ -47,7 +49,7 @@ public class BoletoRecebimento extends Boleto {
     }
 
     public BoletoRecebimento(Cliente cliente, double valor, double juros, double multa, double desconto, Date vencimento,
-                             String logoUrl, String texto, String grupo, String pedidoNumero) {
+            String logoUrl, String texto, String grupo, String pedidoNumero) {
         this.cliente = cliente;
         this.valor = valor;
         this.juros = juros;
@@ -172,29 +174,29 @@ public class BoletoRecebimento extends Boleto {
         this.linkGrupo = linkGrupo;
     }
 
-    public int getDiasIndisponibilizar() {
+    public String getDiasIndisponibilizar() {
         return diasIndisponibilizar;
     }
 
     /**
      * Número de dias não pode ser maior do que 58.<br><br>
-     * <b>Importante: </b>Só vai funcionar em boletos emitidos nos bancos: 
+     * <b>Importante: </b>Só vai funcionar em boletos emitidos nos bancos:
      * <ul>
      * <li>BPP</li>
      * <li>Itaú</li>
      * <li>Santander</li>
      * </ul>
-     * Para travar um banco basta nos solicitar pelo e-mail 
-     * atendimento@pjbank.com.br e informar qual prefere usar. Isso não impacta 
+     * Para travar um banco basta nos solicitar pelo e-mail
+     * atendimento@pjbank.com.br e informar qual prefere usar. Isso não impacta
      * em nada para você, seu cliente ou quem irá pagar).
      *
      * @param diasIndisponibilizar
      */
-    public void setDiasIndisponibilizar(int diasIndisponibilizar) {
+    public void setDiasIndisponibilizar(String diasIndisponibilizar) {
         this.diasIndisponibilizar = diasIndisponibilizar;
     }
 
-    public int getDiasJuros() {
+    public String getDiasJuros() {
         return diasJuros;
     }
 
@@ -209,17 +211,17 @@ public class BoletoRecebimento extends Boleto {
      *
      * @param diasJuros
      */
-    public void setDiasJuros(int diasJuros) {
+    public void setDiasJuros(String diasJuros) {
         this.diasJuros = diasJuros;
     }
 
-    public int getDiasMulta() {
+    public String getDiasMulta() {
         return diasMulta;
     }
 
     /**
      * Indica a quantidade de dias após o vencimento para se cobrar multa.<br>
-     * Bancos que aceitam o "atraso" na cobrança de multa: 
+     * Bancos que aceitam o "atraso" na cobrança de multa:
      * <ul>
      * <li>001 - Banco do Brasil</li>
      * <li>033 - Santander</li>
@@ -228,21 +230,21 @@ public class BoletoRecebimento extends Boleto {
      *
      * @param diasMulta
      */
-    public void setDiasMulta(int diasMulta) {
+    public void setDiasMulta(String diasMulta) {
         this.diasMulta = diasMulta;
     }
 
-    public int getNuncaAtualizarBoleto() {
+    public EnumAtualizarVencimento getNuncaAtualizarBoleto() {
         return nuncaAtualizarBoleto;
     }
 
     /**
-     * Informar valor 1 para não atualizar o vencimento boleto de forma
-     * automática. Valor padrão 0.
+     * É utilizado para que o vencimento do boleto não seja atualizado
+     * automaticamente, caso caia em um fim de semana ou feriado.
      *
      * @param nuncaAtualizarBoleto
      */
-    public void setNuncaAtualizarBoleto(int nuncaAtualizarBoleto) {
+    public void setNuncaAtualizarBoleto(EnumAtualizarVencimento nuncaAtualizarBoleto) {
         this.nuncaAtualizarBoleto = nuncaAtualizarBoleto;
     }
 
@@ -251,11 +253,12 @@ public class BoletoRecebimento extends Boleto {
     }
 
     /**
-     * Mostra o QR Code no boleto ou substitui o boleto por apenas QR
+     * <code>EnumPix.PIX</code> - Substitui o boleto pelo QRCode do Pix<br>
+     * <code>EnumPix.PIX_E_BOLETO</code> - Imprimi o QRCode no boleto
      * Code.<br><br>
      * <b>Importante:</b>
      * Não gera o QRCode se gerar um boleto vencido
-     * 
+     *
      * @see br.com.pjbank.sdk.models.common.EnumPix
      * @param pix
      */

--- a/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
+++ b/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
@@ -35,6 +35,7 @@ import org.apache.http.client.methods.HttpDelete;
  * @since 1.0
  */
 public class BoletosManager extends PJBankAuthenticatedService {
+
     /**
      * EndPoint a ser requisitado na API
      */
@@ -48,6 +49,7 @@ public class BoletosManager extends PJBankAuthenticatedService {
 
     /**
      * Realiza a emissão do boleto bancário para o cliente informado
+     *
      * @param boletoRecebimento: boleto à ser emitido
      * @return BoletoRecebimento
      */
@@ -76,10 +78,10 @@ public class BoletosManager extends PJBankAuthenticatedService {
         params.put("texto", boletoRecebimento.getTexto());
         params.put("grupo", boletoRecebimento.getGrupo());
         params.put("pedido_numero", boletoRecebimento.getPedidoNumero());
-        params.put("dias_indisponibilizar", String.valueOf(boletoRecebimento.getDiasIndisponibilizar()));
-        params.put("dias_juros", boletoRecebimento.getDiasJuros());
-        params.put("dias_multa", boletoRecebimento.getDiasMulta());
-        params.put("nunca_atualizar_boleto", boletoRecebimento.getNuncaAtualizarBoleto());
+        params.putOpt("dias_indisponibilizar", boletoRecebimento.getDiasIndisponibilizar());
+        params.putOpt("dias_juros", boletoRecebimento.getDiasJuros());
+        params.putOpt("dias_multa", boletoRecebimento.getDiasMulta());
+        params.putOpt("nunca_atualizar_boleto", boletoRecebimento.getNuncaAtualizarBoleto().getValue());
         params.put("pix", boletoRecebimento.getPix().getDescricao());
 
         httpPost.setEntity(new StringEntity(params.toString(), StandardCharsets.UTF_8));
@@ -94,7 +96,7 @@ public class BoletosManager extends PJBankAuthenticatedService {
 
         return boletoRecebimento;
     }
-    
+
     /**
      * Retorna a lista de boletos emitidos por códigos de pedidos
      * @param pedidos: Lista de códigos de pedidos os quais deseja retornar os boletos
@@ -143,25 +145,25 @@ public class BoletosManager extends PJBankAuthenticatedService {
             );
 
             String dataVencimento = itemExtrato.getString("data_vencimento");
-            if (!StringUtils.isBlank(dataVencimento))
+            if (!StringUtils.isBlank(dataVencimento)) 
                 extrato.setDataVencimento(dateFormat.parse(dataVencimento));
 
             String dataPagamento = itemExtrato.getString("data_pagamento");
-            if (!StringUtils.isBlank(dataPagamento))
+            if (!StringUtils.isBlank(dataPagamento)) 
                 extrato.setDataPagamento(dateFormat.parse(dataPagamento));
 
             String dataCredito = itemExtrato.getString("data_credito");
-            if (!StringUtils.isBlank(dataCredito))
+            if (!StringUtils.isBlank(dataCredito)) 
                 extrato.setDataCredito(dateFormat.parse(dataCredito));
 
             extratos.add(extrato);
         }
         return extratos;
     }
-	
-	private void adicionarFiltros(HttpRequestBase httpRequestClient, Date inicio, Date fim, StatusPagamentoBoleto pago, Integer pagina)
+
+    private void adicionarFiltros(HttpRequestBase httpRequestClient, Date inicio, Date fim, StatusPagamentoBoleto pago, Integer pagina)
             throws URISyntaxException {
-		SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yyyy");
+        SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yyyy");
         URIBuilder uriBuilder = new URIBuilder(httpRequestClient.getURI());
 
         uriBuilder.addParameter("data_inicio", formatter.format(inicio));

--- a/src/test/java/br/com/pjbank/sdk/recebimento/BoletosManagerTest.java
+++ b/src/test/java/br/com/pjbank/sdk/recebimento/BoletosManagerTest.java
@@ -27,6 +27,8 @@ import br.com.pjbank.sdk.enums.StatusPagamentoBoleto;
 import br.com.pjbank.sdk.exceptions.PJBankException;
 import br.com.pjbank.sdk.models.common.Cliente;
 import br.com.pjbank.sdk.models.common.Endereco;
+import br.com.pjbank.sdk.models.common.EnumAtualizarVencimento;
+import br.com.pjbank.sdk.models.common.EnumPix;
 import br.com.pjbank.sdk.models.recebimento.BoletoInvalido;
 import br.com.pjbank.sdk.models.recebimento.BoletoRecebimento;
 import br.com.pjbank.sdk.models.recebimento.ExtratoBoleto;
@@ -76,6 +78,11 @@ public class BoletosManagerTest {
         boletoRecebimento.setTexto("Teste de emissão de boleto via API");
         boletoRecebimento.setGrupo("Boletos");
         boletoRecebimento.setPedidoNumero("9999");
+        boletoRecebimento.setPix(EnumPix.PIX_E_BOLETO);
+        boletoRecebimento.setDiasIndisponibilizar("10");
+        boletoRecebimento.setDiasJuros("5");
+        boletoRecebimento.setDiasMulta("5");
+        boletoRecebimento.setNuncaAtualizarBoleto(EnumAtualizarVencimento.NAO_ATUALIZAR);
 
         BoletosManager boletosManager = new BoletosManager(this.credencial, this.chave);
 


### PR DESCRIPTION
Adicionando os campos:
- `"pix"` (para mostrar _QR Code_ no boleto);
- `"dias_indisponibilizar"` (dias para boleto ser cancelado após o vencimento);
- `"dias_juros"` (dias após o vencimento para cobrar juros);
- `"dias_multa"` (dias após o vencimento para cobrar multa);
- `"nunca_atualizar_boleto"` (se deve atualizar o boleto após o vencimento ou caso o vencimento esteja em uma data não útil).

---

**NOTAS**: De acordo com o contato do PJBank os campos:

- `"dias_indisponibilizar"` funciona somente para **BPP, Santander ou Itaú**.
- `"dias_juros"` e `"dias_multa"` funciona somente para **BPP, Santander, Banco do Brasil**.

Para "travar" um banco deve entrar em contato pelo e-mail atendimento@pjbank.com.br.
O boleto será registrado em até **2 horas**.

#time 2h