### PR TITLE
Parâmetro Pix como Opcional.

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
+++ b/src/main/java/br/com/pjbank/sdk/recebimento/BoletosManager.java
@@ -82,7 +82,7 @@ public class BoletosManager extends PJBankAuthenticatedService {
         params.putOpt("dias_juros", boletoRecebimento.getDiasJuros());
         params.putOpt("dias_multa", boletoRecebimento.getDiasMulta());
         params.putOpt("nunca_atualizar_boleto", boletoRecebimento.getNuncaAtualizarBoleto().getValue());
-        params.put("pix", boletoRecebimento.getPix().getDescricao());
+        params.putOpt("pix", boletoRecebimento.getPix().getDescricao());
 
         httpPost.setEntity(new StringEntity(params.toString(), StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Nem todos os clientes querem habilitar o QRCode do Pix no boleto (cliente CDL - Câmara dos Dirigentes Logistas).

Tornando atributo pix como opcional.

#time 5m
